### PR TITLE
❗️Do not merge❗️-  Refine safir statistics cronjob

### DIFF
--- a/charts/safir/templates/cronjobs/safir-update-statistics.yaml
+++ b/charts/safir/templates/cronjobs/safir-update-statistics.yaml
@@ -34,7 +34,8 @@ spec:
           {{- if .Values.global.imagePullSecrets }}
           imagePullSecrets: {{- include "common.tplvalues.render" (dict "value" .Values.global.imagePullSecrets "context" $) | nindent 12 }}
           {{- end }}
-          restartPolicy: OnFailure
+          restartPolicy: Never
+          activeDeadlineSeconds: 600
           {{- if .Values.podSecurityContext.enabled }}
           securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
##  safir-update-statistics

These were causing issues, when they are stalled somehow and too many start running in parallel.
- Set `restartPolicy` to `never` since they are not that important, but resource-hungry
- Added `activeDeadlineSeconds`. If they're not done after 10 minutes, something is wrong.
